### PR TITLE
Remove dev dependencies to FOS User

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,5 @@
   "require": {
     "triagens/ArangoDb": ">=2.0.0",
     "symfony/framework-bundle": ">=2.1.0,<=2.7"
-  },
-  "require-dev": {
-    "friendsofsymfony/user-bundle": "~1.3.0",
-    "symfony/validator" : ">=2.1.0,<=2.7"
   }
 }


### PR DESCRIPTION
I remember why i didn't include the requirements. the fos user stuff should really be a separate bundle which we should create after these refactorings. dependency back and forth however should not happen. For now you need to require these in your application so the bundle can use them :S